### PR TITLE
Restructuring of the 5GMS documentation

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -1,3 +1,0 @@
-.side-bar {
-  width: 30%;
-}

--- a/pages/5g-media-streaming/repositories/repositories.md
+++ b/pages/5g-media-streaming/repositories/repositories.md
@@ -1,0 +1,54 @@
+---
+layout: default
+title: Repositories
+parent: 5G Downlink Media Streaming
+has_children: true
+nav_order: 3
+---
+
+# ⭐ Related repositories
+Please note that 5G Media Streaming makes use of other generic [5G Core Network components](https://5g-mag.github.io/Getting-Started/pages/5g-core-network-components/)
+
+## 5GMS Application Provider: [rt-5gms-application-provider](https://github.com/5G-MAG/rt-5gms-application-provider)
+* [Information and how to download, build, install and run](https://github.com/5G-MAG/rt-5gms-application-provider#readme)
+* [Releases](https://github.com/5G-MAG/rt-5gms-application-provider/releases)
+* [Projects](https://github.com/5G-MAG/rt-5gms-application-provider/projects?query=is%3Aopen)
+
+## 5GMSd Application Function: [rt-5gms-application-function](https://github.com/5G-MAG/rt-5gms-application-function)
+* [Information and how to download, build, install and run](https://github.com/5G-MAG/rt-5gms-application-function#readme)
+* [Guidelines, development and testing](https://github.com/5G-MAG/rt-5gms-application-function/wiki)
+* [Releases](https://github.com/5G-MAG/rt-5gms-application-function/releases)
+* [Projects](https://github.com/5G-MAG/rt-5gms-application-function/projects?query=is%3Aopen)
+
+## 5GMSd Application Server: [rt-5gms-application-server](https://github.com/5G-MAG/rt-5gms-application-server)
+* [Information and how to download, build, install and run](https://github.com/5G-MAG/rt-5gms-application-server#readme)
+* [Guidelines, development and testing](https://github.com/5G-MAG/rt-5gms-application-server/wiki)
+* [Releases](https://github.com/5G-MAG/rt-5gms-application-server/releases)
+* [Projects](https://github.com/5G-MAG/rt-5gms-application-server/projects?query=is%3Aopen)
+
+## 5GMSd Media Session Handler: [rt-5gms-media-session-handler](https://github.com/5G-MAG/rt-5gms-media-session-handler)
+* [Information and how to download, build, install and run](https://github.com/5G-MAG/rt-5gms-media-session-handler#readme)
+* [Releases](https://github.com/5G-MAG/rt-5gms-media-session-handler/releases)
+
+## 5GMSd Media Stream Handler: [rt-5gms-media-stream-handler](https://github.com/5G-MAG/rt-5gms-media-stream-handler)
+* [Information and how to download, build, install and run](https://github.com/5G-MAG/rt-5gms-media-stream-handler#readme)
+* [Releases](https://github.com/5G-MAG/rt-5gms-media-stream-handler/releases)
+* [Packages](https://github.com/orgs/5G-MAG/packages?repo_name=rt-5gms-media-stream-handler)
+
+## 5GMSd-Aware Applications: [rt-5gms-application](https://github.com/5G-MAG/rt-5gms-application)
+* [Information and how to download, build, install and run](https://github.com/5G-MAG/rt-5gms-application#readme)
+* [Releases](https://github.com/5G-MAG/rt-5gms-application/releases)
+
+# Auxiliary repositories
+
+## 5GMSd Common Android Library: [rt-5gms-common-android-library](https://github.com/5G-MAG/rt-5gms-common-android-library)
+* [Information and how to download, build, install and run](https://github.com/5G-MAG/rt-5gms-common-android-library#readme)
+* [Releases](https://github.com/5G-MAG/rt-5gms-common-android-library/releases)
+* [Packages](https://github.com/orgs/5G-MAG/packages?repo_name=rt-5gms-common-android-library)
+
+## 5GMSd Examples: [rt-5gms-examples](https://github.com/5G-MAG/rt-5gms-examples)
+* [Information](https://github.com/5G-MAG/rt-5gms-examples#readme)
+* [Releases](https://github.com/5G-MAG/rt-5gms-examples/releases)
+
+## Tools common to various projects: [rt-common-shared](https://github.com/5G-MAG/rt-common-shared)
+* [Information](https://github.com/5G-MAG/rt-common-shared#readme)

--- a/pages/5g-media-streaming/tutorials/tutorials.md
+++ b/pages/5g-media-streaming/tutorials/tutorials.md
@@ -3,7 +3,7 @@ layout: default
 title: Tutorials
 parent: 5G Downlink Media Streaming
 has_children: true
-nav_order: 4
+nav_order: 5
 ---
 
 # ▶️ Using the tools

--- a/pages/5g-media-streaming/usage/5gms-aware-application/usage-5gms-aware-application.md
+++ b/pages/5g-media-streaming/usage/5gms-aware-application/usage-5gms-aware-application.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: 5GMS Aware Application
+parent: Usage
+grand_parent: 5G Downlink Media Streaming
+has_children: true
+nav_order: 4
+---
+
+# 5GMS Aware Application

--- a/pages/5g-media-streaming/usage/application-function/configuration-5GMSAF.md
+++ b/pages/5g-media-streaming/usage/application-function/configuration-5GMSAF.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title:  Configuration 5GMS AF
-parent: Tutorials
-grand_parent: 5G Downlink Media Streaming
+parent: Application Function
+grand_parent: Usage
 has_children: false
 nav_order: 1
 ---

--- a/pages/5g-media-streaming/usage/application-function/features-af.md
+++ b/pages/5g-media-streaming/usage/application-function/features-af.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title:  Features 5GMS AF
-parent: Repositories
-grand_parent: 5G Downlink Media Streaming
+parent: Application Function
+grand_parent: Usage
 has_children: false
 nav_order: 0
 ---

--- a/pages/5g-media-streaming/usage/application-function/installation-local-user-5GMSAF.md
+++ b/pages/5g-media-streaming/usage/application-function/installation-local-user-5GMSAF.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title:  Installation 5GMS AF as Local User
-parent: Testing
-grand_parent: 5G Downlink Media Streaming
+parent: Application Function
+grand_parent: Usage
 has_children: false
 nav_order: 1
 ---

--- a/pages/5g-media-streaming/usage/application-function/installation-system-service-5GMSAF.md
+++ b/pages/5g-media-streaming/usage/application-function/installation-system-service-5GMSAF.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title:  Installation 5GMS AF as System Service
-parent: Testing
-grand_parent: 5G Downlink Media Streaming
+parent: Application Function
+grand_parent: Usage
 has_children: false
 nav_order: 2
 ---

--- a/pages/5g-media-streaming/usage/application-function/testing-m1-v120.md
+++ b/pages/5g-media-streaming/usage/application-function/testing-m1-v120.md
@@ -1,17 +1,15 @@
 ---
 layout: default
-title:  Testing M1 AF v1.4.x
-parent: Testing
-grand_parent: 5G Downlink Media Streaming
+title:  Testing M1 AF v1.2.x
+parent: Application Function
+grand_parent: Usage
 has_children: false
-nav_order: 8
+nav_order: 6
 ---
 
-# Testing: M1 Interface (5GMSd Application Function v1.4.1 and later)
+# Testing: M1 Interface (5GMSd Application Function v1.2.x)
 
 To prepare, follow the instructions for [local user building and installation](Testing-as-a-Local-User).
-
-# Testing
 
 These tests require a [5GMSd Application Server](https://github.com/5G-MAG/rt-5gms-application-server) to be running. Please follow
 the instructions to [build, install and run the 5GMSd Application Server](https://github.com/5G-MAG/rt-5gms-application-server#readme) as a system service or the [instructions to run the AS as a local user](https://github.com/5G-MAG/rt-5gms-application-server/wiki/Development-and-Testing) for a temporary installation for testing.
@@ -39,13 +37,13 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Create a single Provisioning Session:
 
    ```bash
-   m1-session new-provisioning-session -e MyAppId -a MyASPId
+   ~/rt-5gms-application-function/install/bin/m1-session new-provisioning-session -e MyAppId -a MyASPId
    ```
 
 1. Check the Provisioning Session:
 
    ```bash
-   m1-session list
+   ~/rt-5gms-application-function/install/bin/m1-session list
    ```
 
    This should list a single provisioning session.
@@ -53,13 +51,13 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Create a second Provisioning Session:
 
    ```bash
-   m1-session new-provisioning-session -e MyAppId -a MyASPId
+   ~/rt-5gms-application-function/install/bin/m1-session new-provisioning-session -e MyAppId -a MyASPId
    ```
 
 1. Check the Provisioning Sessions:
 
    ```bash
-   m1-session list
+   ~/rt-5gms-application-function/install/bin/m1-session list
    ```
 
    This should list the two provisioning sessions.
@@ -83,13 +81,13 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Create a single Provisioning Session with Content Hosting Configuration
 
    ```bash
-   m1-session new-stream -e MyAppId -a MyASPId -n 'Big Buck Bunny' 'https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/' 'BigBuckBunny_4s_onDemand_2014_05_09.mpd'
+   ~/rt-5gms-application-function/install/bin/m1-session new-stream -e MyAppId -a MyASPId -n 'Big Buck Bunny' 'https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/' 'BigBuckBunny_4s_onDemand_2014_05_09.mpd'
    ```
 
 1. Check the Provisioning Session details:
 
    ```bash
-   m1-session list -v
+   ~/rt-5gms-application-function/install/bin/m1-session list -v
    ```
 
    This will list the provisioning session showing the Content Hosting Configuration attached to it.
@@ -97,20 +95,17 @@ This will test the ability of the Application Function to allocate and retrieve 
    For example:
 
    ```
-   39f4f698-daa0-41ed-862b-c1f4c44bccf3:
+   1c961622-c803-41ed-83c5-e304b44dbd7e:
      Certificates:
      ContentHostingConfiguration:
        Name: Big Buck Bunny
+       Entry Point Path: BigBuckBunny_4s_onDemand_2014_05_09.mpd
        Ingest:
-         Type: urn:3gpp:5gms:content-protocol:http-pull-ingest
-         Pull Ingest?: True
-         URL: https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/
+           Type: urn:3gpp:5gms:content-protocol:http-pull-ingest
+           URL: https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/
        Distributions:
-       - URL: http://localhost/m4d/provisioning-session-39f4f698-daa0-41ed-862b-c1f4c44bccf3/
-         Canonical Domain Name: localhost
-         Entry point:
-           Relative Path: BigBuckBunny_4s_onDemand_2014_05_09.mpd
-           Content Type: application/dash+xml
+         - URL: http://localhost/m4d/provisioning-session-1c961622-c803-41ed-83c5-e304b44dbd7e/
+           Canonical Domain Name: localhost
    ```
 
 ### Delete a provisioning session
@@ -132,15 +127,13 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Create a single Provisioning Session:
 
    ```bash
-   m1-session new-provisioning-session -e MyAppId -a MyASPId
+   ~/rt-5gms-application-function/install/bin/m1-session new-provisioning-session -e MyAppId -a MyASPId
    ```
-
-   **Hint:** Set the shell variable `provisioning_session_id` to the returned provisioning session id for use in later commands.
 
 1. Check the Provisioning Session:
 
    ```bash
-   m1-session list
+   ~/rt-5gms-application-function/install/bin/m1-session list
    ```
 
    This should list a single provisioning session.
@@ -148,7 +141,7 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Delete the Provisioning Session by Id:
 
    ```bash
-   m1-session del-stream -p ${provisioning_session_id}
+   ~/rt-5gms-application-function/install/bin/m1-session del-stream -p ${provisioning_session_id}
    ```
 
    Where `${provisioning_session_id}` is the provisioning session id of the session that was created in the earlier step.
@@ -156,13 +149,13 @@ This will test the ability of the Application Function to allocate and retrieve 
    For example:
 
    ```bash
-   m1-session del-stream -p 1c961622-c803-41ed-83c5-e304b44dbd7e
+   ~/rt-5gms-application-function/install/bin/m1-session del-stream -p 1c961622-c803-41ed-83c5-e304b44dbd7e
    ```
 
 1. Check the Provisioning Session is deleted:
 
    ```bash
-   m1-session list
+   ~/rt-5gms-application-function/install/bin/m1-session list
    ```
 
    There should be no provisioning sessions listed.
@@ -170,158 +163,28 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Create a single Provisioning Session with a stream identifier:
 
    ```bash
-   m1-session new-stream -e MyAppId -a MyASPId -n 'Test Stream' 'https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/' 'BigBuckBunny_4s_onDemand_2014_05_09.mpd'
+   ~/rt-5gms-application-function/install/bin/m1-session new-stream -e MyAppId -a MyASPId -n 'Test Stream' 'https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/' 'BigBuckBunny_4s_onDemand_2014_05_09.mpd'
    ```
 
 1. Check the Provisioning Session:
 
    ```bash
-   m1-session list -v
+   ~/rt-5gms-application-function/install/bin/m1-session list -v
    ```
 
 1. Delete the Provisioning Session by ingest URL and entry point path:
 
    ```bash
-   m1-session del-stream 'https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/' 'BigBuckBunny_4s_onDemand_2014_05_09.mpd'
+   ~/rt-5gms-application-function/install/bin/m1-session del-stream 'https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/' 'BigBuckBunny_4s_onDemand_2014_05_09.mpd'
    ```
-
-   **Note:** The entry point (last command line parameter) can be any one of the entry point relative paths present in a
-   distribution configuration for the content hosting configuration of a provisioning session.
 
 1. Check the Provisioning Session is deleted:
 
    ```bash
-   m1-session list
+   ~/rt-5gms-application-function/install/bin/m1-session list
    ```
 
    There should be no provisioning sessions listed.
-
-### Create a hosting configuration with multiple entry points
-
-1. Stop the Application Function if it is already running.
-
-1. Remove previous configurations:
-
-   ```bash
-   rm -rf ~/rt-5gms-application-function/install/var/cache/rt-5gms/af/certificates
-   ```
-
-1. Start the Application Function:
-
-   ```bash
-   ~/rt-5gms-application-function/install/bin/open5gs-msafd
-   ```
-
-1. Create a single Provisioning Session with Content Hosting Configuration containing multiple entry points
-
-   ```bash
-   m1-session new-stream -e MyAppId -a MyASPId -n 'Big Buck Bunny' 'http://amssamples.streaming.mediaservices.windows.net/622b189f-ec39-43f2-93a2-201ac4e31ce1/BigBuckBunny.ism/' 'manifest(format=mpd-time-csf)' 'manifest(format=m3u8-aapl-v3)' 
-   ```
-
-1. Check the Provisioning Session details:
-
-   ```bash
-   m1-session list -v
-   ```
-
-   This will list the provisioning session showing the Content Hosting Configuration attached to it.
-
-   For example:
-
-   ```
-   74f4c492-dacf-41ed-87fe-93ba2b9b790a:
-     Certificates:
-     ContentHostingConfiguration:
-       Name: Big Buck Bunny
-       Ingest:
-         Type: urn:3gpp:5gms:content-protocol:http-pull-ingest
-         Pull Ingest?: True
-         URL: http://amssamples.streaming.mediaservices.windows.net/622b189f-ec39-43f2-93a2-201ac4e31ce1/BigBuckBunny.ism/
-       Distributions:
-       - URL: http://localhost/m4d/provisioning-session-74f4c492-dacf-41ed-87fe-93ba2b9b790a/
-         Canonical Domain Name: localhost
-         Entry point:
-           Relative Path: manifest(format=mpd-time-csf)
-           Content Type: application/dash+xml
-       - URL: http://localhost/m4d/provisioning-session-74f4c492-dacf-41ed-87fe-93ba2b9b790a/
-         Canonical Domain Name: localhost
-         Entry point:
-           Relative Path: manifest(format=m3u8-aapl-v3)
-           Content Type: application/vnd.apple.mpegurl
-   ```
-
-   The output shows that the ContentHostingConfiguration for Provisioning Session 74f4c492-dacf-41ed-87fe-93ba2b9b790a has two
-   distribution configurations. There is one distribution configuration for DASH and one for HLS.
-
-### Create a hosting configuration from a JSON file
-
-1. Stop the Application Function if it is already running.
-
-1. Remove previous configurations:
-
-   ```bash
-   rm -rf ~/rt-5gms-application-function/install/var/cache/rt-5gms/af/certificates
-   ```
-
-1. Start the Application Function:
-
-   ```bash
-   ~/rt-5gms-application-function/install/bin/open5gs-msafd
-   ```
-
-1. Create a single Provisioning Session:
-
-   ```bash
-   m1-session new-provisioning-session -e MyAppId -a MyASPId
-   ```
-
-   **Hint:** Set the shell variable `provisioning_session_id` to the returned provisioning session id for use in later commands.
-
-1. Upload the ContentHostingConfiguration JSON file:
-
-   ```bash
-   m1-session set-stream -p ${provisioning_session_id} ~/rt-5gms-application-function/examples/ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest.json
-   ```
-
-   Where `${provisioning_session_id}` is the Provisioning Session Id reported by the previous step.
-
-   For this step one of the example configuration files from the `~/rt-5gms-application-function/examples` directory was used, but any valid ContentHostingConfiguration JSON file can be used.
-
-1. Check the Provisioning Session:
-
-   ```bash
-   m1-session list -v
-   ```
-
-   The output should show a provisioning session with the contents of the JSON file used as the ContentHostingConfiguration.
-
-   For example:
-
-   ```
-   74f4c492-dacf-41ed-87fe-93ba2b9b790a:
-     Certificates:
-     ContentHostingConfiguration:
-       Name: AMP Demo Stream: Big Buck Bunny
-       Ingest:
-         Type: urn:3gpp:5gms:content-protocol:http-pull-ingest
-         Pull Ingest?: True
-         URL: http://amssamples.streaming.mediaservices.windows.net/622b189f-ec39-43f2-93a2-201ac4e31ce1/BigBuckBunny.ism/
-       Distributions:
-       - URL: http://localhost/m4d/provisioning-session-74f4c492-dacf-41ed-87fe-93ba2b9b790a/
-         Canonical Domain Name: localhost
-         Entry point:
-           Relative Path: manifest(format=mpd-time-csf)
-           Content Type: application/dash+xml
-           Profiles:
-           - urn:mpeg:dash:profile:isoff-live:2011
-       - URL: http://localhost/m4d/provisioning-session-74f4c492-dacf-41ed-87fe-93ba2b9b790a/
-         Canonical Domain Name: localhost
-         Entry point:
-           Relative Path: manifest(format=m3u8-aapl-v3)
-           Content Type: application/vnd.apple.mpegurl
-   ```
-
-   This also tests the use of profile lists in the distribution entry points.
 
 ## Server Certificates
 
@@ -344,15 +207,13 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Create a single Provisioning Session:
 
    ```bash
-   m1-session new-provisioning-session -e MyAppId -a MyASPId
+   ~/rt-5gms-application-function/install/bin/m1-session new-provisioning-session -e MyAppId -a MyASPId
    ```
-
-   **Hint:** Set the shell variable `provisioning_session_id` to the returned provisioning session id for use in later commands.
 
 1. Create a certificate:
 
    ```bash
-   m1-session new-certificate -p ${provisioning_session_id}
+   ~/rt-5gms-application-function/install/bin/m1-session new-certificate -p ${provisioning_session_id}
    ```
 
    Where `${provisioning_session_id}` is the provisioning session id of the session that was created in the previous step.
@@ -360,7 +221,7 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Check the Provisioning Session:
 
    ```bash
-   m1-session list -v
+   ~/rt-5gms-application-function/install/bin/m1-session list -v
    ```
 
    The output should show a provisioning session with a single certificate where the subject and issuer of the certificate are
@@ -393,7 +254,7 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Create a certificate with a domain name:
 
    ```bash
-   m1-session new-certificate -p ${provisioning_session_id} -d as.example.com
+   ~/rt-5gms-application-function/install/bin/m1-session new-certificate -p ${provisioning_session_id} -d as.example.com
    ```
 
    Since a domain name was requested, the `m1-session` tool will request a CSR from the 5GMSd Application Function and sign it
@@ -402,7 +263,7 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Check the Provisioning Session:
 
    ```bash
-   m1-session list -v
+   ~/rt-5gms-application-function/install/bin/m1-session list -v
    ```
 
    The output should now show an extra certificate on the provisioning session.
@@ -445,7 +306,7 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Reserve a certificate:
 
    ```bash
-   m1-session new-certificate -p ${provisioning_session_id} --csr
+   ~/rt-5gms-application-function/install/bin/m1-session new-certificate -p ${provisioning_session_id} --csr
    ```
 
    The output includes the new certificate id and a CSR in PEM format.
@@ -453,7 +314,7 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Check the Provisioning Session:
 
     ```bash
-   m1-session list -v
+   ~/rt-5gms-application-function/install/bin/m1-session list -v
    ```
 
    The output should now show a third certificate id but the certificate detail says "Certificate not yet uploaded".
@@ -511,25 +372,21 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Create a single Provisioning Session:
 
    ```bash
-   m1-session new-provisioning-session -e MyAppId -a MyASPId
+   ~/rt-5gms-application-function/install/bin/m1-session new-provisioning-session -e MyAppId -a MyASPId
    ```
-
-   **Hint:** Set the shell variable `provisioning_session_id` to the returned provisioning session id for use in later commands.
 
 1. Create a certificate
 
    ```bash
-   m1-session new-certificate -p ${provisioning_session_id}
+   ~/rt-5gms-application-function/install/bin/m1-session new-certificate -p ${provisioning_session_id}
    ```
 
    Where `${provisioning_session_id}` is the provisioning session id of the session that was created in the previous step.
 
-   **Hint:** Set the shell variable `certificate_id` to the returned certificate id for use in later commands.
-
 1. Display the details of the certificate
 
    ```bash
-   m1-session show-certificate -p ${provisioning_session_id} -c ${certificate_id}
+   ~/rt-5gms-application-function/install/bin/m1-session show-certificate -p ${provisioning_session_id} -c ${certificate_id}
    ```
 
    Where `${provisioning_session_id}` is the provisioning session id of the session that was created in step 4 and
@@ -555,7 +412,7 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Display the public certificate PEM data
 
    ```bash
-   m1-session show-certificate -p ${provisioning_session_id} -c ${certificate_id} -r
+   ~/rt-5gms-application-function/install/bin/m1-session show-certificate -p ${provisioning_session_id} -c ${certificate_id} -r
    ```
 
    The `-r` flag causes the command to display the "raw" output which is the PEM data for the certificate.
@@ -610,15 +467,13 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Create a single Provisioning Session:
 
    ```bash
-   m1-session new-provisioning-session -e MyAppId -a MyASPId
+   ~/rt-5gms-application-function/install/bin/m1-session new-provisioning-session -e MyAppId -a MyASPId
    ```
-
-   **Hint:** Set the shell variable `provisioning_session_id` to the returned provisioning session id for use in later commands.
 
 1. List the Content Protocols for the Provisioning Session
 
    ```bash
-   m1-session protocols -p ${provisioning_session_id}
+   ~/rt-5gms-application-function/install/bin/m1-session protocols -p ${provisioning_session_id}
    ```
 
    Where `${provisioning_session_id}` is the provisioning session id of the session that was created in the previous step.
@@ -656,15 +511,13 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Create a single Provisioning Session:
 
    ```bash
-   m1-session new-provisioning-session -e MyAppId -a MyASPId
+   ~/rt-5gms-application-function/install/bin/m1-session new-provisioning-session -e MyAppId -a MyASPId
    ```
-
-   **Hint:** Set the shell variable `provisioning_session_id` to the returned provisioning session id for use in later commands.
 
 1. Create the hosting configuration:
 
    ```bash
-   m1-session set-stream -p ${provisioning_session_id} ~/rt-5gms-application-function/examples/ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest.json
+   ~/rt-5gms-application-function/install/bin/m1-session set-stream -p ${provisioning_session_id} ~/rt-5gms-application-function/examples/ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest.json
    ```
 
    Where `${provisioning_session_id}` is the provisioning session id of the session that was created in the previous step.
@@ -672,7 +525,7 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Check the provisioning session configuration:
 
    ```bash
-   m1-session list -v
+   ~/rt-5gms-application-function/install/bin/m1-session list -v
    ```
 
    This will display the provisioning session created, showing no certificates and the details from the example
@@ -697,7 +550,7 @@ This will test the ability of the Application Function to allocate and retrieve 
 **Note:** The `m1-session new-stream` command is a convience command that will create a provisioning session, generate the
 ContentHostingConfiguration and set it in the newly created provisioning session. The above can also be done using:
 ```
-m1-session new-stream -e MyAppId -a MyASPId -n 'Big Buck Bunny' 'https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/' 'BigBuckBunny_4s_onDemand_2014_05_09.mpd'
+~/rt-5gms-application-function/install/bin/m1-session new-stream -e MyAppId -a MyASPId -n 'Big Buck Bunny' 'https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/' 'BigBuckBunny_4s_onDemand_2014_05_09.mpd'
 ```
 
 ### Add a Content Hosting Configuration which uses an existing certificate
@@ -719,15 +572,13 @@ m1-session new-stream -e MyAppId -a MyASPId -n 'Big Buck Bunny' 'https://ftp.ite
 1. Create a single Provisioning Session:
 
    ```bash
-   m1-session new-provisioning-session -e MyAppId -a MyASPId
+   ~/rt-5gms-application-function/install/bin/m1-session new-provisioning-session -e MyAppId -a MyASPId
    ```
-
-   **Hint:** Set the shell variable `provisioning_session_id` to the returned provisioning session id for use in later commands.
 
 1. Create a certificate:
 
    ```bash
-   m1-session new-certificate -p ${provisioning_session_id}
+   ~/rt-5gms-application-function/install/bin/m1-session new-certificate -p ${provisioning_session_id}
    ```
 
    Where `${provisioning_session_id}` is the provisioning session id of the session that was created in the previous step.
@@ -743,7 +594,7 @@ m1-session new-stream -e MyAppId -a MyASPId -n 'Big Buck Bunny' 'https://ftp.ite
 1. Create the hosting configuration using the generated ContentHostingConfiguration:
 
    ```bash
-   m1-session set-stream -p ${provisioning_session_id} chc.json
+   ~/rt-5gms-application-function/install/bin/m1-session set-stream -p ${provisioning_session_id} chc.json
    ```
 
    Where `${provisioning_session_id}` is the provisioning session id of the session that was created in step 4.
@@ -751,7 +602,7 @@ m1-session new-stream -e MyAppId -a MyASPId -n 'Big Buck Bunny' 'https://ftp.ite
 1. Check the provisioning session configuration:
 
    ```bash
-   m1-session list -v
+   ~/rt-5gms-application-function/install/bin/m1-session list -v
    ```
 
    This will display the provisioning session created, showing no certificates and the details from the example
@@ -787,73 +638,5 @@ m1-session new-stream -e MyAppId -a MyASPId -n 'Big Buck Bunny' 'https://ftp.ite
 **Note:** The `m1-session new-stream` command is a convience command that will create a provisioning session, generate the
 ContentHostingConfiguration and set it in the newly created provisioning session. The above configuration with the `m1-session` tool can also be done using this single command instead:
 ```
-m1-session new-stream -e MyAppId -a MyASPId -n 'Big Buck Bunny' --ssl-only 'https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/' 'BigBuckBunny_4s_onDemand_2014_05_09.mpd'
+~/rt-5gms-application-function/install/bin/m1-session new-stream -e MyAppId -a MyASPId -n 'Big Buck Bunny' --ssl-only 'https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/' 'BigBuckBunny_4s_onDemand_2014_05_09.mpd'
 ```
-
-## Consumption Reporting (v1.4.0 and later)
-
-### Add a Consumption Reporting Configuration
-
-1. Stop the Application Function if it is already running.
-
-1. Remove previous configurations:
-
-   ```bash
-   rm -rf ~/rt-5gms-application-function/install/var/cache/rt-5gms/af/certificates
-   ```
-
-1. Start the Application Function:
-
-   ```bash
-   ~/rt-5gms-application-function/install/bin/open5gs-msafd
-   ```
-
-1. Create a single Provisioning Session:
-
-   ```bash
-   m1-session new-provisioning-session -e MyAppId -a MyASPId
-   ```
-
-   **Hint:** Set the shell variable `provisioning_session_id` to the returned provisioning session id for use in later commands.
-
-1. Create a Consumption Reporting Configuration for the Provisioning Session
-   ```bash
-   m1-session set-consumption-reporting -p ${provisioning_session_id} --interval 15 --sample-percentage 66.66 --location-reporting --access-reporting
-   ```
-
-   Where `${provisioning_session_id}` is the provisioning session id of the session that was created in step 4.
-
-   This will set consumption reporting to every 15 seconds for 66.66% of clients and reports should include Location and Access reporting.
-
-   All Consumption Reporting parameters are optional so doing the following:
-   ```bash
-   m1-session set-consumption-reporting -p ${provisioning_session_id}
-   ```
-   ...will request all clients send a single Consumption Report at the end of the media without Location or Access reports (the defaults for consumption reporting).
-
-### Show current Consumption Reporting Configuration
-
-1. Display the current Consumption Reporting Configuration for a Provisioning Session
-   ```bash
-   m1-session show-consumption-reporting -p ${provisioning_session_id}
-   ```
-
-   Where `${provisioning_session_id}` is the provisioning session id of the session you wish to view.
-
-### Remove the Consumption Reporting Configuration
-
-1. Remove Consumption Reporting from a Provisioning Session
-   ```bash
-   m1-session del-consumption-reporting -p ${provisioning_session_id}
-   ```
-
-   Where `${provisioning_session_id}` is the provisioning session id of the session you wish to remove consumption reporting from.
-
-1. Display the current Consumption Reporting Configuration for the Provisioning Session to check it has gone
-   ```bash
-   m1-session show-consumption-reporting -p ${provisioning_session_id}
-   ```
-
-   Where `${provisioning_session_id}` is the provisioning session id of the session you wish to view.
-
-   This will report no Consumption Reporting Configuration is present.

--- a/pages/5g-media-streaming/usage/application-function/testing-m1-v130.md
+++ b/pages/5g-media-streaming/usage/application-function/testing-m1-v130.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title:  Testing M1 AF v1.3.x
-parent: Testing
-grand_parent: 5G Downlink Media Streaming
+parent: Application Function
+grand_parent: Usage
 has_children: false
 nav_order: 7
 ---

--- a/pages/5g-media-streaming/usage/application-function/testing-m1-v141.md
+++ b/pages/5g-media-streaming/usage/application-function/testing-m1-v141.md
@@ -1,15 +1,17 @@
 ---
 layout: default
-title:  Testing M1 AF v1.2.x
-parent: Testing
-grand_parent: 5G Downlink Media Streaming
+title:  Testing M1 AF v1.4.x
+parent: Application Function
+grand_parent: Usage
 has_children: false
-nav_order: 6
+nav_order: 8
 ---
 
-# Testing: M1 Interface (5GMSd Application Function v1.2.x)
+# Testing: M1 Interface (5GMSd Application Function v1.4.1 and later)
 
 To prepare, follow the instructions for [local user building and installation](Testing-as-a-Local-User).
+
+# Testing
 
 These tests require a [5GMSd Application Server](https://github.com/5G-MAG/rt-5gms-application-server) to be running. Please follow
 the instructions to [build, install and run the 5GMSd Application Server](https://github.com/5G-MAG/rt-5gms-application-server#readme) as a system service or the [instructions to run the AS as a local user](https://github.com/5G-MAG/rt-5gms-application-server/wiki/Development-and-Testing) for a temporary installation for testing.
@@ -37,13 +39,13 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Create a single Provisioning Session:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session new-provisioning-session -e MyAppId -a MyASPId
+   m1-session new-provisioning-session -e MyAppId -a MyASPId
    ```
 
 1. Check the Provisioning Session:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session list
+   m1-session list
    ```
 
    This should list a single provisioning session.
@@ -51,13 +53,13 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Create a second Provisioning Session:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session new-provisioning-session -e MyAppId -a MyASPId
+   m1-session new-provisioning-session -e MyAppId -a MyASPId
    ```
 
 1. Check the Provisioning Sessions:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session list
+   m1-session list
    ```
 
    This should list the two provisioning sessions.
@@ -81,13 +83,13 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Create a single Provisioning Session with Content Hosting Configuration
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session new-stream -e MyAppId -a MyASPId -n 'Big Buck Bunny' 'https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/' 'BigBuckBunny_4s_onDemand_2014_05_09.mpd'
+   m1-session new-stream -e MyAppId -a MyASPId -n 'Big Buck Bunny' 'https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/' 'BigBuckBunny_4s_onDemand_2014_05_09.mpd'
    ```
 
 1. Check the Provisioning Session details:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session list -v
+   m1-session list -v
    ```
 
    This will list the provisioning session showing the Content Hosting Configuration attached to it.
@@ -95,17 +97,20 @@ This will test the ability of the Application Function to allocate and retrieve 
    For example:
 
    ```
-   1c961622-c803-41ed-83c5-e304b44dbd7e:
+   39f4f698-daa0-41ed-862b-c1f4c44bccf3:
      Certificates:
      ContentHostingConfiguration:
        Name: Big Buck Bunny
-       Entry Point Path: BigBuckBunny_4s_onDemand_2014_05_09.mpd
        Ingest:
-           Type: urn:3gpp:5gms:content-protocol:http-pull-ingest
-           URL: https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/
+         Type: urn:3gpp:5gms:content-protocol:http-pull-ingest
+         Pull Ingest?: True
+         URL: https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/
        Distributions:
-         - URL: http://localhost/m4d/provisioning-session-1c961622-c803-41ed-83c5-e304b44dbd7e/
-           Canonical Domain Name: localhost
+       - URL: http://localhost/m4d/provisioning-session-39f4f698-daa0-41ed-862b-c1f4c44bccf3/
+         Canonical Domain Name: localhost
+         Entry point:
+           Relative Path: BigBuckBunny_4s_onDemand_2014_05_09.mpd
+           Content Type: application/dash+xml
    ```
 
 ### Delete a provisioning session
@@ -127,13 +132,15 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Create a single Provisioning Session:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session new-provisioning-session -e MyAppId -a MyASPId
+   m1-session new-provisioning-session -e MyAppId -a MyASPId
    ```
+
+   **Hint:** Set the shell variable `provisioning_session_id` to the returned provisioning session id for use in later commands.
 
 1. Check the Provisioning Session:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session list
+   m1-session list
    ```
 
    This should list a single provisioning session.
@@ -141,7 +148,7 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Delete the Provisioning Session by Id:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session del-stream -p ${provisioning_session_id}
+   m1-session del-stream -p ${provisioning_session_id}
    ```
 
    Where `${provisioning_session_id}` is the provisioning session id of the session that was created in the earlier step.
@@ -149,13 +156,13 @@ This will test the ability of the Application Function to allocate and retrieve 
    For example:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session del-stream -p 1c961622-c803-41ed-83c5-e304b44dbd7e
+   m1-session del-stream -p 1c961622-c803-41ed-83c5-e304b44dbd7e
    ```
 
 1. Check the Provisioning Session is deleted:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session list
+   m1-session list
    ```
 
    There should be no provisioning sessions listed.
@@ -163,28 +170,158 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Create a single Provisioning Session with a stream identifier:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session new-stream -e MyAppId -a MyASPId -n 'Test Stream' 'https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/' 'BigBuckBunny_4s_onDemand_2014_05_09.mpd'
+   m1-session new-stream -e MyAppId -a MyASPId -n 'Test Stream' 'https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/' 'BigBuckBunny_4s_onDemand_2014_05_09.mpd'
    ```
 
 1. Check the Provisioning Session:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session list -v
+   m1-session list -v
    ```
 
 1. Delete the Provisioning Session by ingest URL and entry point path:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session del-stream 'https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/' 'BigBuckBunny_4s_onDemand_2014_05_09.mpd'
+   m1-session del-stream 'https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/' 'BigBuckBunny_4s_onDemand_2014_05_09.mpd'
    ```
+
+   **Note:** The entry point (last command line parameter) can be any one of the entry point relative paths present in a
+   distribution configuration for the content hosting configuration of a provisioning session.
 
 1. Check the Provisioning Session is deleted:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session list
+   m1-session list
    ```
 
    There should be no provisioning sessions listed.
+
+### Create a hosting configuration with multiple entry points
+
+1. Stop the Application Function if it is already running.
+
+1. Remove previous configurations:
+
+   ```bash
+   rm -rf ~/rt-5gms-application-function/install/var/cache/rt-5gms/af/certificates
+   ```
+
+1. Start the Application Function:
+
+   ```bash
+   ~/rt-5gms-application-function/install/bin/open5gs-msafd
+   ```
+
+1. Create a single Provisioning Session with Content Hosting Configuration containing multiple entry points
+
+   ```bash
+   m1-session new-stream -e MyAppId -a MyASPId -n 'Big Buck Bunny' 'http://amssamples.streaming.mediaservices.windows.net/622b189f-ec39-43f2-93a2-201ac4e31ce1/BigBuckBunny.ism/' 'manifest(format=mpd-time-csf)' 'manifest(format=m3u8-aapl-v3)' 
+   ```
+
+1. Check the Provisioning Session details:
+
+   ```bash
+   m1-session list -v
+   ```
+
+   This will list the provisioning session showing the Content Hosting Configuration attached to it.
+
+   For example:
+
+   ```
+   74f4c492-dacf-41ed-87fe-93ba2b9b790a:
+     Certificates:
+     ContentHostingConfiguration:
+       Name: Big Buck Bunny
+       Ingest:
+         Type: urn:3gpp:5gms:content-protocol:http-pull-ingest
+         Pull Ingest?: True
+         URL: http://amssamples.streaming.mediaservices.windows.net/622b189f-ec39-43f2-93a2-201ac4e31ce1/BigBuckBunny.ism/
+       Distributions:
+       - URL: http://localhost/m4d/provisioning-session-74f4c492-dacf-41ed-87fe-93ba2b9b790a/
+         Canonical Domain Name: localhost
+         Entry point:
+           Relative Path: manifest(format=mpd-time-csf)
+           Content Type: application/dash+xml
+       - URL: http://localhost/m4d/provisioning-session-74f4c492-dacf-41ed-87fe-93ba2b9b790a/
+         Canonical Domain Name: localhost
+         Entry point:
+           Relative Path: manifest(format=m3u8-aapl-v3)
+           Content Type: application/vnd.apple.mpegurl
+   ```
+
+   The output shows that the ContentHostingConfiguration for Provisioning Session 74f4c492-dacf-41ed-87fe-93ba2b9b790a has two
+   distribution configurations. There is one distribution configuration for DASH and one for HLS.
+
+### Create a hosting configuration from a JSON file
+
+1. Stop the Application Function if it is already running.
+
+1. Remove previous configurations:
+
+   ```bash
+   rm -rf ~/rt-5gms-application-function/install/var/cache/rt-5gms/af/certificates
+   ```
+
+1. Start the Application Function:
+
+   ```bash
+   ~/rt-5gms-application-function/install/bin/open5gs-msafd
+   ```
+
+1. Create a single Provisioning Session:
+
+   ```bash
+   m1-session new-provisioning-session -e MyAppId -a MyASPId
+   ```
+
+   **Hint:** Set the shell variable `provisioning_session_id` to the returned provisioning session id for use in later commands.
+
+1. Upload the ContentHostingConfiguration JSON file:
+
+   ```bash
+   m1-session set-stream -p ${provisioning_session_id} ~/rt-5gms-application-function/examples/ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest.json
+   ```
+
+   Where `${provisioning_session_id}` is the Provisioning Session Id reported by the previous step.
+
+   For this step one of the example configuration files from the `~/rt-5gms-application-function/examples` directory was used, but any valid ContentHostingConfiguration JSON file can be used.
+
+1. Check the Provisioning Session:
+
+   ```bash
+   m1-session list -v
+   ```
+
+   The output should show a provisioning session with the contents of the JSON file used as the ContentHostingConfiguration.
+
+   For example:
+
+   ```
+   74f4c492-dacf-41ed-87fe-93ba2b9b790a:
+     Certificates:
+     ContentHostingConfiguration:
+       Name: AMP Demo Stream: Big Buck Bunny
+       Ingest:
+         Type: urn:3gpp:5gms:content-protocol:http-pull-ingest
+         Pull Ingest?: True
+         URL: http://amssamples.streaming.mediaservices.windows.net/622b189f-ec39-43f2-93a2-201ac4e31ce1/BigBuckBunny.ism/
+       Distributions:
+       - URL: http://localhost/m4d/provisioning-session-74f4c492-dacf-41ed-87fe-93ba2b9b790a/
+         Canonical Domain Name: localhost
+         Entry point:
+           Relative Path: manifest(format=mpd-time-csf)
+           Content Type: application/dash+xml
+           Profiles:
+           - urn:mpeg:dash:profile:isoff-live:2011
+       - URL: http://localhost/m4d/provisioning-session-74f4c492-dacf-41ed-87fe-93ba2b9b790a/
+         Canonical Domain Name: localhost
+         Entry point:
+           Relative Path: manifest(format=m3u8-aapl-v3)
+           Content Type: application/vnd.apple.mpegurl
+   ```
+
+   This also tests the use of profile lists in the distribution entry points.
 
 ## Server Certificates
 
@@ -207,13 +344,15 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Create a single Provisioning Session:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session new-provisioning-session -e MyAppId -a MyASPId
+   m1-session new-provisioning-session -e MyAppId -a MyASPId
    ```
+
+   **Hint:** Set the shell variable `provisioning_session_id` to the returned provisioning session id for use in later commands.
 
 1. Create a certificate:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session new-certificate -p ${provisioning_session_id}
+   m1-session new-certificate -p ${provisioning_session_id}
    ```
 
    Where `${provisioning_session_id}` is the provisioning session id of the session that was created in the previous step.
@@ -221,7 +360,7 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Check the Provisioning Session:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session list -v
+   m1-session list -v
    ```
 
    The output should show a provisioning session with a single certificate where the subject and issuer of the certificate are
@@ -254,7 +393,7 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Create a certificate with a domain name:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session new-certificate -p ${provisioning_session_id} -d as.example.com
+   m1-session new-certificate -p ${provisioning_session_id} -d as.example.com
    ```
 
    Since a domain name was requested, the `m1-session` tool will request a CSR from the 5GMSd Application Function and sign it
@@ -263,7 +402,7 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Check the Provisioning Session:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session list -v
+   m1-session list -v
    ```
 
    The output should now show an extra certificate on the provisioning session.
@@ -306,7 +445,7 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Reserve a certificate:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session new-certificate -p ${provisioning_session_id} --csr
+   m1-session new-certificate -p ${provisioning_session_id} --csr
    ```
 
    The output includes the new certificate id and a CSR in PEM format.
@@ -314,7 +453,7 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Check the Provisioning Session:
 
     ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session list -v
+   m1-session list -v
    ```
 
    The output should now show a third certificate id but the certificate detail says "Certificate not yet uploaded".
@@ -372,21 +511,25 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Create a single Provisioning Session:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session new-provisioning-session -e MyAppId -a MyASPId
+   m1-session new-provisioning-session -e MyAppId -a MyASPId
    ```
+
+   **Hint:** Set the shell variable `provisioning_session_id` to the returned provisioning session id for use in later commands.
 
 1. Create a certificate
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session new-certificate -p ${provisioning_session_id}
+   m1-session new-certificate -p ${provisioning_session_id}
    ```
 
    Where `${provisioning_session_id}` is the provisioning session id of the session that was created in the previous step.
 
+   **Hint:** Set the shell variable `certificate_id` to the returned certificate id for use in later commands.
+
 1. Display the details of the certificate
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session show-certificate -p ${provisioning_session_id} -c ${certificate_id}
+   m1-session show-certificate -p ${provisioning_session_id} -c ${certificate_id}
    ```
 
    Where `${provisioning_session_id}` is the provisioning session id of the session that was created in step 4 and
@@ -412,7 +555,7 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Display the public certificate PEM data
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session show-certificate -p ${provisioning_session_id} -c ${certificate_id} -r
+   m1-session show-certificate -p ${provisioning_session_id} -c ${certificate_id} -r
    ```
 
    The `-r` flag causes the command to display the "raw" output which is the PEM data for the certificate.
@@ -467,13 +610,15 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Create a single Provisioning Session:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session new-provisioning-session -e MyAppId -a MyASPId
+   m1-session new-provisioning-session -e MyAppId -a MyASPId
    ```
+
+   **Hint:** Set the shell variable `provisioning_session_id` to the returned provisioning session id for use in later commands.
 
 1. List the Content Protocols for the Provisioning Session
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session protocols -p ${provisioning_session_id}
+   m1-session protocols -p ${provisioning_session_id}
    ```
 
    Where `${provisioning_session_id}` is the provisioning session id of the session that was created in the previous step.
@@ -511,13 +656,15 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Create a single Provisioning Session:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session new-provisioning-session -e MyAppId -a MyASPId
+   m1-session new-provisioning-session -e MyAppId -a MyASPId
    ```
+
+   **Hint:** Set the shell variable `provisioning_session_id` to the returned provisioning session id for use in later commands.
 
 1. Create the hosting configuration:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session set-stream -p ${provisioning_session_id} ~/rt-5gms-application-function/examples/ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest.json
+   m1-session set-stream -p ${provisioning_session_id} ~/rt-5gms-application-function/examples/ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest.json
    ```
 
    Where `${provisioning_session_id}` is the provisioning session id of the session that was created in the previous step.
@@ -525,7 +672,7 @@ This will test the ability of the Application Function to allocate and retrieve 
 1. Check the provisioning session configuration:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session list -v
+   m1-session list -v
    ```
 
    This will display the provisioning session created, showing no certificates and the details from the example
@@ -550,7 +697,7 @@ This will test the ability of the Application Function to allocate and retrieve 
 **Note:** The `m1-session new-stream` command is a convience command that will create a provisioning session, generate the
 ContentHostingConfiguration and set it in the newly created provisioning session. The above can also be done using:
 ```
-~/rt-5gms-application-function/install/bin/m1-session new-stream -e MyAppId -a MyASPId -n 'Big Buck Bunny' 'https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/' 'BigBuckBunny_4s_onDemand_2014_05_09.mpd'
+m1-session new-stream -e MyAppId -a MyASPId -n 'Big Buck Bunny' 'https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/' 'BigBuckBunny_4s_onDemand_2014_05_09.mpd'
 ```
 
 ### Add a Content Hosting Configuration which uses an existing certificate
@@ -572,13 +719,15 @@ ContentHostingConfiguration and set it in the newly created provisioning session
 1. Create a single Provisioning Session:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session new-provisioning-session -e MyAppId -a MyASPId
+   m1-session new-provisioning-session -e MyAppId -a MyASPId
    ```
+
+   **Hint:** Set the shell variable `provisioning_session_id` to the returned provisioning session id for use in later commands.
 
 1. Create a certificate:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session new-certificate -p ${provisioning_session_id}
+   m1-session new-certificate -p ${provisioning_session_id}
    ```
 
    Where `${provisioning_session_id}` is the provisioning session id of the session that was created in the previous step.
@@ -594,7 +743,7 @@ ContentHostingConfiguration and set it in the newly created provisioning session
 1. Create the hosting configuration using the generated ContentHostingConfiguration:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session set-stream -p ${provisioning_session_id} chc.json
+   m1-session set-stream -p ${provisioning_session_id} chc.json
    ```
 
    Where `${provisioning_session_id}` is the provisioning session id of the session that was created in step 4.
@@ -602,7 +751,7 @@ ContentHostingConfiguration and set it in the newly created provisioning session
 1. Check the provisioning session configuration:
 
    ```bash
-   ~/rt-5gms-application-function/install/bin/m1-session list -v
+   m1-session list -v
    ```
 
    This will display the provisioning session created, showing no certificates and the details from the example
@@ -638,5 +787,73 @@ ContentHostingConfiguration and set it in the newly created provisioning session
 **Note:** The `m1-session new-stream` command is a convience command that will create a provisioning session, generate the
 ContentHostingConfiguration and set it in the newly created provisioning session. The above configuration with the `m1-session` tool can also be done using this single command instead:
 ```
-~/rt-5gms-application-function/install/bin/m1-session new-stream -e MyAppId -a MyASPId -n 'Big Buck Bunny' --ssl-only 'https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/' 'BigBuckBunny_4s_onDemand_2014_05_09.mpd'
+m1-session new-stream -e MyAppId -a MyASPId -n 'Big Buck Bunny' --ssl-only 'https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/' 'BigBuckBunny_4s_onDemand_2014_05_09.mpd'
 ```
+
+## Consumption Reporting (v1.4.0 and later)
+
+### Add a Consumption Reporting Configuration
+
+1. Stop the Application Function if it is already running.
+
+1. Remove previous configurations:
+
+   ```bash
+   rm -rf ~/rt-5gms-application-function/install/var/cache/rt-5gms/af/certificates
+   ```
+
+1. Start the Application Function:
+
+   ```bash
+   ~/rt-5gms-application-function/install/bin/open5gs-msafd
+   ```
+
+1. Create a single Provisioning Session:
+
+   ```bash
+   m1-session new-provisioning-session -e MyAppId -a MyASPId
+   ```
+
+   **Hint:** Set the shell variable `provisioning_session_id` to the returned provisioning session id for use in later commands.
+
+1. Create a Consumption Reporting Configuration for the Provisioning Session
+   ```bash
+   m1-session set-consumption-reporting -p ${provisioning_session_id} --interval 15 --sample-percentage 66.66 --location-reporting --access-reporting
+   ```
+
+   Where `${provisioning_session_id}` is the provisioning session id of the session that was created in step 4.
+
+   This will set consumption reporting to every 15 seconds for 66.66% of clients and reports should include Location and Access reporting.
+
+   All Consumption Reporting parameters are optional so doing the following:
+   ```bash
+   m1-session set-consumption-reporting -p ${provisioning_session_id}
+   ```
+   ...will request all clients send a single Consumption Report at the end of the media without Location or Access reports (the defaults for consumption reporting).
+
+### Show current Consumption Reporting Configuration
+
+1. Display the current Consumption Reporting Configuration for a Provisioning Session
+   ```bash
+   m1-session show-consumption-reporting -p ${provisioning_session_id}
+   ```
+
+   Where `${provisioning_session_id}` is the provisioning session id of the session you wish to view.
+
+### Remove the Consumption Reporting Configuration
+
+1. Remove Consumption Reporting from a Provisioning Session
+   ```bash
+   m1-session del-consumption-reporting -p ${provisioning_session_id}
+   ```
+
+   Where `${provisioning_session_id}` is the provisioning session id of the session you wish to remove consumption reporting from.
+
+1. Display the current Consumption Reporting Configuration for the Provisioning Session to check it has gone
+   ```bash
+   m1-session show-consumption-reporting -p ${provisioning_session_id}
+   ```
+
+   Where `${provisioning_session_id}` is the provisioning session id of the session you wish to view.
+
+   This will report no Consumption Reporting Configuration is present.

--- a/pages/5g-media-streaming/usage/application-function/testing-m3-v110.md
+++ b/pages/5g-media-streaming/usage/application-function/testing-m3-v110.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title:  Testing M3 AF v1.1.x
-parent: Testing
-grand_parent: 5G Downlink Media Streaming
+parent: Application Function
+grand_parent: Usage
 has_children: false
 nav_order: 9
 ---

--- a/pages/5g-media-streaming/usage/application-function/testing-m3-v120.md
+++ b/pages/5g-media-streaming/usage/application-function/testing-m3-v120.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title:  Testing M3 AF v1.2.x
-parent: Testing
-grand_parent: 5G Downlink Media Streaming
+parent: Application Function
+grand_parent: Usage
 has_children: false
 nav_order: 10
 ---

--- a/pages/5g-media-streaming/usage/application-function/testing-m5-v100.md
+++ b/pages/5g-media-streaming/usage/application-function/testing-m5-v100.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title:  Testing M5 AF v1.0.x
-parent: Testing
-grand_parent: 5G Downlink Media Streaming
+parent: Application Function
+grand_parent: Usage
 has_children: false
 nav_order: 11
 ---

--- a/pages/5g-media-streaming/usage/application-function/testing-m5-v120.md
+++ b/pages/5g-media-streaming/usage/application-function/testing-m5-v120.md
@@ -1,13 +1,13 @@
 ---
 layout: default
-title:  Testing M5 AF v1.3.x
-parent: Testing
-grand_parent: 5G Downlink Media Streaming
+title:  Testing M5 AF v1.2.x
+parent: Application Function
+grand_parent: Usage
 has_children: false
-nav_order: 13
+nav_order: 12
 ---
 
-# Testing: M5 Interface (5GMSd Application Function v1.3.0 and above)
+# Testing: M5 Interface (5GMSd Application Function v1.2.x)
 
 To prepare, follow the instructions for [local user building and installation](Testing-as-a-Local-User).
 
@@ -118,28 +118,22 @@ If the ContentHostingConfiguration does not contain any `distributionConfigurati
    Expected result:
 
    ```
-   > GET /3gpp-m5/v2/service-access-information/f863831c-daa8-41ed-862b-c1f4c44bccf3 HTTP/1.1
+   > GET /3gpp-m5/v2/service-access-information/0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c HTTP/1.1
    > Host: 127.0.0.24:7777
    > User-Agent: curl/7.85.0
    > Accept: */*
    > 
    < HTTP/1.1 200 OK
-   < Date: Fri, 14 Apr 2023 09:44:47 GMT
+   < Date: Tue, 07 Feb 2023 12:11:56 GMT
    < Connection: close
    < Content-Type: application/json
-   < ETag: 38548172d8eca143db6b4b11af8df6dea66d62acb45f751c9348f257c9682165
-   < Last-Modified: Fri, 14 Apr 2023 09:44:37 GMT
-   < Cache-Control: max-age=60
-   < Server: 5GMSdAF-localhost/17 (info.title=M5_ServiceAccessInformation; info.version=2.2.0) rt-5gms-application-function/1.3.0
-   < Content-Length: 339
+   < Content-Length: 278
+   < 
    {
-       "provisioningSessionId":	"f863831c-daa8-41ed-862b-c1f4c44bccf3",
+       "provisioningSessionId":	"0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c",
        "provisioningSessionType":	"DOWNLINK",
        "streamingAccess":	{
-           "entryPoints":	[{
-               "locator":	"http://localhost/m4d/provisioning-session-f863831c-daa8-41ed-862b-c1f4c44bccf3/BigBuckBunny_4s_onDemand_2014_05_09.mpd",
-               "contentType":	"application/dash+xml"
-           }]
+           "mediaPlayerEntry":	"http://localhost/m4d/provisioning-session-0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c/BigBuckBunny_4s_onDemand_2014_05_09.mpd"
        }
    }
    ```
@@ -179,38 +173,31 @@ for the `mediaPlayerEntry` in the ServiceAccessInformation.
 
 1. Using the provisioning session id, returned from the `m1-session` command, perform a GET request on the interface URL
 
-   Example command if the provisioning session id is 30c20cea-daab-41ed-87fe-93ba2b9b790a:
+   Example command if the provisioning session id is 0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c:
 
    ```bash
-   curl -v 'http://127.0.0.24:7777/3gpp-m5/v2/service-access-information/30c20cea-daab-41ed-87fe-93ba2b9b790a'
+   curl -v 'http://127.0.0.24:7777/3gpp-m5/v2/service-access-information/0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c'
    ```
 
-   Expected result should look like:
+   Expected result:
 
    ```
-   > GET /3gpp-m5/v2/service-access-information/30c20cea-daab-41ed-87fe-93ba2b9b790a HTTP/1.1
+   > GET /3gpp-m5/v2/service-access-information/0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c HTTP/1.1
    > Host: 127.0.0.24:7777
    > User-Agent: curl/7.85.0
    > Accept: */*
-   > 
+   >
    < HTTP/1.1 200 OK
-   < Date: Fri, 14 Apr 2023 10:00:40 GMT
+   < Date: Tue, 07 Feb 2023 12:11:56 GMT
    < Connection: close
-   < ETag: 8c12228d39cd5e015fdab5e7972084a6bbd12747b4c482e0cdc1ce82bbac597e
-   < Last-Modified: Fri, 14 Apr 2023 10:00:31 GMT
-   < Cache-Control: max-age=60
-   < Server: 5GMSdAF-localhost/17 (info.title=M5_ServiceAccessInformation; info.version=2.2.0) rt-5gms-application-function/1.3.0
    < Content-Type: application/json
-   < Content-Length: 340
-   < 
+   < Content-Length: 278
+   <
    {
-       "provisioningSessionId":	"30c20cea-daab-41ed-87fe-93ba2b9b790a",
-       "provisioningSessionType":	"DOWNLINK",
-       "streamingAccess":	{
-           "entryPoints":	[{
-               "locator":	"https://localhost/m4d/provisioning-session-30c20cea-daab-41ed-87fe-93ba2b9b790a/BigBuckBunny_4s_onDemand_2014_05_09.mpd",
-               "contentType":	"application/dash+xml"
-           }]
+       "provisioningSessionId":    "0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c",
+       "provisioningSessionType":  "DOWNLINK",
+       "streamingAccess":  {
+           "mediaPlayerEntry": "https://localhost/m4d/provisioning-session-0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c/BigBuckBunny_4s_onDemand_2014_05_09.mpd"
        }
    }
    ```
@@ -253,38 +240,31 @@ To test this:
 
 1. Using the provisioning session id, returned from the `m1-session` command, perform a GET request on the interface URL
 
-   Example command if the provisioning session id is efbff530-daab-41ed-87fe-93ba2b9b790a:
+   Example command if the provisioning session id is 0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c:
 
    ```bash
-   curl -v 'http://127.0.0.24:7777/3gpp-m5/v2/service-access-information/efbff530-daab-41ed-87fe-93ba2b9b790a'
+   curl -v 'http://127.0.0.24:7777/3gpp-m5/v2/service-access-information/0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c'
    ```
 
    Expected result:
 
    ```
-   > GET /3gpp-m5/v2/service-access-information/efbff530-daab-41ed-87fe-93ba2b9b790a HTTP/1.1
+   > GET /3gpp-m5/v2/service-access-information/0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c HTTP/1.1
    > Host: 127.0.0.24:7777
    > User-Agent: curl/7.85.0
    > Accept: */*
-   > 
+   >
    < HTTP/1.1 200 OK
-   < Date: Fri, 14 Apr 2023 10:06:01 GMT
+   < Date: Tue, 07 Feb 2023 12:11:56 GMT
    < Connection: close
-   < ETag: f5dd70a781efeefed1c034bbe640119019e1a46a55dcf50cfcccae8a323139ad
-   < Last-Modified: Fri, 14 Apr 2023 10:05:51 GMT
-   < Cache-Control: max-age=60
-   < Server: 5GMSdAF-localhost/17 (info.title=M5_ServiceAccessInformation; info.version=2.2.0) rt-5gms-application-function/1.3.0
    < Content-Type: application/json
-   < Content-Length: 347
-   < 
+   < Content-Length: 278
+   <
    {
-       "provisioningSessionId":	"efbff530-daab-41ed-87fe-93ba2b9b790a",
-       "provisioningSessionType":	"DOWNLINK",
-       "streamingAccess":	{
-           "entryPoints":	[{
-               "locator":	"http://media.example.com/m4d/provisioning-session-efbff530-daab-41ed-87fe-93ba2b9b790a/BigBuckBunny_4s_onDemand_2014_05_09.mpd",
-               "contentType":	"application/dash+xml"
-           }]
+       "provisioningSessionId":    "0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c",
+       "provisioningSessionType":  "DOWNLINK",
+       "streamingAccess":  {
+           "mediaPlayerEntry": "https://media.example.com/m4d/provisioning-session-0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c/BigBuckBunny_4s_onDemand_2014_05_09.mpd"
        }
    }
    ```
@@ -338,7 +318,6 @@ To test this
    < HTTP/1.1 404 Not Found
    < Date: Tue, 07 Feb 2023 14:47:26 GMT
    < Connection: close
-   < Server: 5GMSdAF-localhost/17 (info.title=M5_ServiceAccessInformation; info.version=2.2.0) rt-5gms-application-function/1.3.0
    < Content-Type: application/problem+json
    < Content-Length: 208
    < 
@@ -353,16 +332,3 @@ To test this
    **Note:** There may also be additional HTTP library information lines output by curl starting with a `*` character interspersed with the output.
 
    The HTTP response is a 404 status code with the body containing a ProblemDetail JSON object.
-
-## Consumption Reporting
-
-**TODO!**
-
-## Network Assistance
-
-**TODO!**
-
-## Dynamic Policies
-
-**TODO!**
-

--- a/pages/5g-media-streaming/usage/application-function/testing-m5-v130.md
+++ b/pages/5g-media-streaming/usage/application-function/testing-m5-v130.md
@@ -1,13 +1,13 @@
 ---
 layout: default
-title:  Testing M5 AF v1.2.x
-parent: Testing
-grand_parent: 5G Downlink Media Streaming
+title:  Testing M5 AF v1.3.x
+parent: Application Function
+grand_parent: Usage
 has_children: false
-nav_order: 12
+nav_order: 13
 ---
 
-# Testing: M5 Interface (5GMSd Application Function v1.2.x)
+# Testing: M5 Interface (5GMSd Application Function v1.3.0 and above)
 
 To prepare, follow the instructions for [local user building and installation](Testing-as-a-Local-User).
 
@@ -118,22 +118,28 @@ If the ContentHostingConfiguration does not contain any `distributionConfigurati
    Expected result:
 
    ```
-   > GET /3gpp-m5/v2/service-access-information/0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c HTTP/1.1
+   > GET /3gpp-m5/v2/service-access-information/f863831c-daa8-41ed-862b-c1f4c44bccf3 HTTP/1.1
    > Host: 127.0.0.24:7777
    > User-Agent: curl/7.85.0
    > Accept: */*
    > 
    < HTTP/1.1 200 OK
-   < Date: Tue, 07 Feb 2023 12:11:56 GMT
+   < Date: Fri, 14 Apr 2023 09:44:47 GMT
    < Connection: close
    < Content-Type: application/json
-   < Content-Length: 278
-   < 
+   < ETag: 38548172d8eca143db6b4b11af8df6dea66d62acb45f751c9348f257c9682165
+   < Last-Modified: Fri, 14 Apr 2023 09:44:37 GMT
+   < Cache-Control: max-age=60
+   < Server: 5GMSdAF-localhost/17 (info.title=M5_ServiceAccessInformation; info.version=2.2.0) rt-5gms-application-function/1.3.0
+   < Content-Length: 339
    {
-       "provisioningSessionId":	"0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c",
+       "provisioningSessionId":	"f863831c-daa8-41ed-862b-c1f4c44bccf3",
        "provisioningSessionType":	"DOWNLINK",
        "streamingAccess":	{
-           "mediaPlayerEntry":	"http://localhost/m4d/provisioning-session-0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c/BigBuckBunny_4s_onDemand_2014_05_09.mpd"
+           "entryPoints":	[{
+               "locator":	"http://localhost/m4d/provisioning-session-f863831c-daa8-41ed-862b-c1f4c44bccf3/BigBuckBunny_4s_onDemand_2014_05_09.mpd",
+               "contentType":	"application/dash+xml"
+           }]
        }
    }
    ```
@@ -173,31 +179,38 @@ for the `mediaPlayerEntry` in the ServiceAccessInformation.
 
 1. Using the provisioning session id, returned from the `m1-session` command, perform a GET request on the interface URL
 
-   Example command if the provisioning session id is 0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c:
+   Example command if the provisioning session id is 30c20cea-daab-41ed-87fe-93ba2b9b790a:
 
    ```bash
-   curl -v 'http://127.0.0.24:7777/3gpp-m5/v2/service-access-information/0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c'
+   curl -v 'http://127.0.0.24:7777/3gpp-m5/v2/service-access-information/30c20cea-daab-41ed-87fe-93ba2b9b790a'
    ```
 
-   Expected result:
+   Expected result should look like:
 
    ```
-   > GET /3gpp-m5/v2/service-access-information/0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c HTTP/1.1
+   > GET /3gpp-m5/v2/service-access-information/30c20cea-daab-41ed-87fe-93ba2b9b790a HTTP/1.1
    > Host: 127.0.0.24:7777
    > User-Agent: curl/7.85.0
    > Accept: */*
-   >
+   > 
    < HTTP/1.1 200 OK
-   < Date: Tue, 07 Feb 2023 12:11:56 GMT
+   < Date: Fri, 14 Apr 2023 10:00:40 GMT
    < Connection: close
+   < ETag: 8c12228d39cd5e015fdab5e7972084a6bbd12747b4c482e0cdc1ce82bbac597e
+   < Last-Modified: Fri, 14 Apr 2023 10:00:31 GMT
+   < Cache-Control: max-age=60
+   < Server: 5GMSdAF-localhost/17 (info.title=M5_ServiceAccessInformation; info.version=2.2.0) rt-5gms-application-function/1.3.0
    < Content-Type: application/json
-   < Content-Length: 278
-   <
+   < Content-Length: 340
+   < 
    {
-       "provisioningSessionId":    "0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c",
-       "provisioningSessionType":  "DOWNLINK",
-       "streamingAccess":  {
-           "mediaPlayerEntry": "https://localhost/m4d/provisioning-session-0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c/BigBuckBunny_4s_onDemand_2014_05_09.mpd"
+       "provisioningSessionId":	"30c20cea-daab-41ed-87fe-93ba2b9b790a",
+       "provisioningSessionType":	"DOWNLINK",
+       "streamingAccess":	{
+           "entryPoints":	[{
+               "locator":	"https://localhost/m4d/provisioning-session-30c20cea-daab-41ed-87fe-93ba2b9b790a/BigBuckBunny_4s_onDemand_2014_05_09.mpd",
+               "contentType":	"application/dash+xml"
+           }]
        }
    }
    ```
@@ -240,31 +253,38 @@ To test this:
 
 1. Using the provisioning session id, returned from the `m1-session` command, perform a GET request on the interface URL
 
-   Example command if the provisioning session id is 0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c:
+   Example command if the provisioning session id is efbff530-daab-41ed-87fe-93ba2b9b790a:
 
    ```bash
-   curl -v 'http://127.0.0.24:7777/3gpp-m5/v2/service-access-information/0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c'
+   curl -v 'http://127.0.0.24:7777/3gpp-m5/v2/service-access-information/efbff530-daab-41ed-87fe-93ba2b9b790a'
    ```
 
    Expected result:
 
    ```
-   > GET /3gpp-m5/v2/service-access-information/0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c HTTP/1.1
+   > GET /3gpp-m5/v2/service-access-information/efbff530-daab-41ed-87fe-93ba2b9b790a HTTP/1.1
    > Host: 127.0.0.24:7777
    > User-Agent: curl/7.85.0
    > Accept: */*
-   >
+   > 
    < HTTP/1.1 200 OK
-   < Date: Tue, 07 Feb 2023 12:11:56 GMT
+   < Date: Fri, 14 Apr 2023 10:06:01 GMT
    < Connection: close
+   < ETag: f5dd70a781efeefed1c034bbe640119019e1a46a55dcf50cfcccae8a323139ad
+   < Last-Modified: Fri, 14 Apr 2023 10:05:51 GMT
+   < Cache-Control: max-age=60
+   < Server: 5GMSdAF-localhost/17 (info.title=M5_ServiceAccessInformation; info.version=2.2.0) rt-5gms-application-function/1.3.0
    < Content-Type: application/json
-   < Content-Length: 278
-   <
+   < Content-Length: 347
+   < 
    {
-       "provisioningSessionId":    "0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c",
-       "provisioningSessionType":  "DOWNLINK",
-       "streamingAccess":  {
-           "mediaPlayerEntry": "https://media.example.com/m4d/provisioning-session-0c5cc9e6-a6dd-41ed-ae90-e781c44d0f0c/BigBuckBunny_4s_onDemand_2014_05_09.mpd"
+       "provisioningSessionId":	"efbff530-daab-41ed-87fe-93ba2b9b790a",
+       "provisioningSessionType":	"DOWNLINK",
+       "streamingAccess":	{
+           "entryPoints":	[{
+               "locator":	"http://media.example.com/m4d/provisioning-session-efbff530-daab-41ed-87fe-93ba2b9b790a/BigBuckBunny_4s_onDemand_2014_05_09.mpd",
+               "contentType":	"application/dash+xml"
+           }]
        }
    }
    ```
@@ -318,6 +338,7 @@ To test this
    < HTTP/1.1 404 Not Found
    < Date: Tue, 07 Feb 2023 14:47:26 GMT
    < Connection: close
+   < Server: 5GMSdAF-localhost/17 (info.title=M5_ServiceAccessInformation; info.version=2.2.0) rt-5gms-application-function/1.3.0
    < Content-Type: application/problem+json
    < Content-Length: 208
    < 
@@ -332,3 +353,16 @@ To test this
    **Note:** There may also be additional HTTP library information lines output by curl starting with a `*` character interspersed with the output.
 
    The HTTP response is a 404 status code with the body containing a ProblemDetail JSON object.
+
+## Consumption Reporting
+
+**TODO!**
+
+## Network Assistance
+
+**TODO!**
+
+## Dynamic Policies
+
+**TODO!**
+

--- a/pages/5g-media-streaming/usage/application-function/testing-postman.md
+++ b/pages/5g-media-streaming/usage/application-function/testing-postman.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title:  Testing with Postman
-parent: Testing
-grand_parent: 5G Downlink Media Streaming
+parent: Application Function
+grand_parent: Usage
 has_children: false
 nav_order: 5
 ---

--- a/pages/5g-media-streaming/usage/application-function/usage-application-function.md
+++ b/pages/5g-media-streaming/usage/application-function/usage-application-function.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Application Function
+parent: Usage
+grand_parent: 5G Downlink Media Streaming
+has_children: true
+nav_order: 1
+---
+
+# Application Function

--- a/pages/5g-media-streaming/usage/application-server/development-AS.md
+++ b/pages/5g-media-streaming/usage/application-server/development-AS.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title:  Developing the 5GMS AS
-parent: Testing
-grand_parent: 5G Downlink Media Streaming
+parent: Application Server
+grand_parent: Usage
 has_children: false
 nav_order: 4
 ---

--- a/pages/5g-media-streaming/usage/application-server/testing-AS.md
+++ b/pages/5g-media-streaming/usage/application-server/testing-AS.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title:  Testing the 5GMS AS
-parent: Testing
-grand_parent: 5G Downlink Media Streaming
+parent: Application Server
+grand_parent: Usage
 has_children: false
 nav_order: 3
 ---

--- a/pages/5g-media-streaming/usage/application-server/usage-application-server.md
+++ b/pages/5g-media-streaming/usage/application-server/usage-application-server.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Application Server
+parent: Usage
+grand_parent: 5G Downlink Media Streaming
+has_children: true
+nav_order: 2
+---
+
+# Application Server

--- a/pages/5g-media-streaming/usage/compatibility.md
+++ b/pages/5g-media-streaming/usage/compatibility.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-title:  Compability 5GMS components
-parent: Testing
+title:  Compatibility
+parent: Usage
 grand_parent: 5G Downlink Media Streaming
 has_children: false
 nav_order: 0

--- a/pages/5g-media-streaming/usage/media-session-handler/usage-media-session-handler.md
+++ b/pages/5g-media-streaming/usage/media-session-handler/usage-media-session-handler.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Media Session Handler
+parent: Usage
+grand_parent: 5G Downlink Media Streaming
+has_children: true
+nav_order: 3
+---
+
+# Media Session Handler

--- a/pages/5g-media-streaming/usage/usage.md
+++ b/pages/5g-media-streaming/usage/usage.md
@@ -1,11 +1,11 @@
 ---
 layout: default
-title: Testing
+title: Usage
 parent: 5G Downlink Media Streaming
 has_children: true
-nav_order: 3
+nav_order: 4
 ---
-# 🚧 Testing
+# 🚧 Usage
 
 ## Installation of the 5GMS AF as a Local User
 Follow the instructions in this [page](testing/installation-local-user-5GMSAF.html) for setting up a test environment without requiring full


### PR DESCRIPTION
Based on #63 this PR is a suggestion for a minor restructuring:

* Use the term `Usage` instead of `Testing`
* Dedicated folders for the major components in the `usage` folder
* Moved files to respective subfolders and added `grand_parent` for each

To be discussed:
* Move installation instructions for AF to the AF repo
* Add one page as a general overview on how the different components work together