### PR TITLE
remove 'early access' from v3c repositories listing

### DIFF
--- a/pages/v3c-immersive-platform/repositories.md
+++ b/pages/v3c-immersive-platform/repositories.md
@@ -20,7 +20,6 @@ nav_order: 2
 
 <img src="../../assets/images/projects/v3c_repos.png" style="width: 80%">
 
-Note that these repositories are currently private and under testing. **Early access** can be requested at: [https://www.5g-mag.com/early-access](https://www.5g-mag.com/early-access)
 
 ---
 


### PR DESCRIPTION
the v3c repositories are now public