### PR TITLE
Minor updates to tutorial for XR

### DIFF
--- a/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
+++ b/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
@@ -13,7 +13,7 @@ This guide covers compiling the XR player sample Unity project for Android and c
 
 This section assumes [adb](https://developer.android.com/tools/adb) is installed on the machine, and an Android device with [developer options and USB debugging](https://developer.android.com/studio/debug/dev-options#enable) enabled is connected.
 
-The project requires Unity 3D 2022.3.34f1 with both Android and iOS support modules installed. Note that Android API version is set to 26 with NDK 27.2.12479018.
+The project requires **Unity 3D 2022.3.34f1** with both Android and iOS support modules installed. Note that **Android API 26** and **NDK 27.2.12479018** are used.
 
 While this guide assumes a Windows environment with a git-bash terminal (eg. to run shell scripts), the same instructions apply to other platoforms.
 
@@ -64,14 +64,13 @@ cp ./rt-common-shared/avcodec-build/build/ffmpeg/aarch64/LICENSE ./rt-xr-maf-nat
 * Locate the `./rt-xr-maf-native/crossfile/android-arm64-v8a` and modify it to point to your local NDK installation, for instance: 
 ```
 [binaries]
-ar = ['C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk\27.2.12479018\toolchains\llvm\prebuilt\windows-x86_64\bin\llvm-ar']
-c = ['C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk\27.2.12479018\toolchains\llvm\prebuilt\windows-x86_64\bin\aarch64-linux-android28-clang.cmd']
-cpp = ['C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk\27.2.12479018\toolchains\llvm\prebuilt\windows-x86_64\bin\aarch64-linux-android28-clang++.cmd']
-c_ld = ['C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk\27.2.12479018\toolchains\llvm\prebuilt\windows-x86_64\bin\ld.lld']
-cpp_ld = ['C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk\27.2.12479018\toolchains\llvm\prebuilt\windows-x86_64\bin\ld.lld']
-strip = ['C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk\27.2.12479018\toolchains\llvm\prebuilt\windows-x86_64\bin\llvm-strip']
+ar = ['C:\Users\<your_user_name>\AppData\Local\Android\Sdk\ndk\27.2.12479018\toolchains\llvm\prebuilt\windows-x86_64\bin\llvm-ar']
+c = ['C:\Users\<your_user_name>\AppData\Local\Android\Sdk\ndk\27.2.12479018\toolchains\llvm\prebuilt\windows-x86_64\bin\aarch64-linux-android28-clang.cmd']
+cpp = ['C:\Users\<your_user_name>\AppData\Local\Android\Sdk\ndk\27.2.12479018\toolchains\llvm\prebuilt\windows-x86_64\bin\aarch64-linux-android28-clang++.cmd']
+c_ld = ['C:\Users\<your_user_name>\AppData\Local\Android\Sdk\ndk\27.2.12479018\toolchains\llvm\prebuilt\windows-x86_64\bin\ld.lld']
+cpp_ld = ['C:\Users\<your_user_name>\AppData\Local\Android\Sdk\ndk\27.2.12479018\toolchains\llvm\prebuilt\windows-x86_64\bin\ld.lld']
+strip = ['C:\Users\<your_user_name>\AppData\Local\Android\Sdk\ndk\27.2.12479018\toolchains\llvm\prebuilt\windows-x86_64\bin\llvm-strip']
 ```
-
 
 #### configure and compile the MAF library and media pipeline plugins
 
@@ -86,9 +85,9 @@ meson compile -C build/android/arm64-v8a
 
 ### install the media pipeline factory and plugins into the Unity project
 
-Assuming *rt-xr-unity-player* repository has been cloned in a sibling directory `../rt-xr-unity-player`:
+Assuming *rt-xr-unity-player* repository has been cloned in a sibling directory `../rt-xr-unity-player`, run the following commands making sure of the correct path that applies to your installation:
 ```
-export ANDROID_NDK_HOME='/c/Users/fivegmag/AppData/Local/Android/Sdk/ndk/27.2.12479018'
+export ANDROID_NDK_HOME='/c/Users/<your_user_name>/AppData/Local/Android/Sdk/ndk/27.2.12479018'
 cd rt-xr-maf-native
 scripts/install_android.sh ../rt-xr-unity-player/Packages/rt.xr.maf
 ```

--- a/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
+++ b/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
@@ -38,7 +38,7 @@ Note: --recursive is required to get all submodules checked out.
 
 ### Clone and install the source code
 ```
-git clone git@github.com:5G-MAG/rt-xr-maf-native.git
+git clone https://github.com/5G-MAG/rt-xr-maf-native.git
 cd rt-xr-maf-native
 ```
 

--- a/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
+++ b/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
@@ -54,7 +54,7 @@ mkdir -p ./rt-xr-maf-native/subprojects/avpipeline/external/avcodec/android/arm6
 cp ./rt-common-shared/avcodec-build/build/ffmpeg/aarch64/lib/*.so ./rt-xr-maf-native/subprojects/avpipeline/external/avcodec/android/arm64-v8a/lib
 
 mkdir -p ./rt-xr-maf-native/subprojects/avpipeline/external/avcodec/android/arm64-v8a/include
-cp -r ./rt-common-shared/avcodec-build/build/ffmpeg/aarch64/include/ ./rt-xr-maf-native/subprojects/avpipeline/external/avcodec/android/arm64-v8a/include
+cp -r ./rt-common-shared/avcodec-build/build/ffmpeg/aarch64/ ./rt-xr-maf-native/subprojects/avpipeline/external/avcodec/android/arm64-v8a/include
 
 cp ./rt-common-shared/avcodec-build/build/ffmpeg/aarch64/LICENSE ./rt-xr-maf-native/subprojects/avpipeline/external/avcodec/android/arm64-v8a/LICENSE
 ```

--- a/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
+++ b/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
@@ -60,7 +60,7 @@ cp ./rt-common-shared/avcodec-build/build/ffmpeg/aarch64/LICENSE ./rt-xr-maf-nat
 
 #### configure cross compilation configuration 
 
-* Download and install the Android NDK. In the next steps, we assume a Windows x86_64 environment with the Android NDK *27.2.12479018* installed in `C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk`.
+* Download and install the Android NDK. In the next steps, we assume a Windows x86_64 environment with the Android NDK *27.2.12479018* installed in `C:\Users\<your_user_name>\AppData\Local\Android\Sdk\ndk`.
 * Locate the `./rt-xr-maf-native/crossfile/android-arm64-v8a` and modify it to point to your local NDK installation, for instance: 
 ```
 [binaries]

--- a/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
+++ b/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
@@ -88,7 +88,7 @@ meson compile -C build/android/arm64-v8a
 
 Assuming *rt-xr-unity-player* repository has been cloned in a sibling directory `../rt-xr-unity-player`:
 ```
-export ANDROID_NDK_HOME='/c/Users/fivegmag/AppData/Local/Android/Sdk/ndk/28.0.12674087'
+export ANDROID_NDK_HOME='/c/Users/fivegmag/AppData/Local/Android/Sdk/ndk/27.2.12479018'
 cd rt-xr-maf-native
 scripts/install_android.sh ../rt-xr-unity-player/Packages/rt.xr.maf
 ```

--- a/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
+++ b/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
@@ -13,7 +13,7 @@ This guide covers compiling the XR player sample Unity project for Android and c
 
 This section assumes [adb](https://developer.android.com/tools/adb) is installed on the machine, and an Android device with [developer options and USB debugging](https://developer.android.com/studio/debug/dev-options#enable) enabled is connected.
 
-The project requires Unity 3D 2022.3 with both Android and iOS support modules installed.
+The project requires Unity 3D 2022.3 with both Android and iOS support modules installed. Note that Android API version is set to 26 with NDK 28.0.12674087.
 
 While this guide assumes a Windows environment with a git-bash terminal (eg. to run shell scripts), the same instructions apply to other platoforms.
 

--- a/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
+++ b/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
@@ -61,16 +61,16 @@ cp ./rt-common-shared/avcodec-build/build/ffmpeg/aarch64/LICENSE ./rt-xr-maf-nat
 
 #### configure cross compilation configuration 
 
-* Download and install the Android NDK. In the next steps, we assume a Windows x86_64 environment with the Android NDK *28.0.12674087* installed in `C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk`.
+* Download and install the Android NDK. In the next steps, we assume a Windows x86_64 environment with the Android NDK *27.2.12479018* installed in `C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk`.
 * Locate the `./rt-xr-maf-native/crossfile/android-arm64-v8a` and modify it to point to your local NDK installation, for instance: 
 ```
 [binaries]
-ar = ['C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk\28.0.12674087\toolchains\llvm\prebuilt\windows-x86_64\bin\llvm-ar']
-c = ['C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk\28.0.12674087\toolchains\llvm\prebuilt\windows-x86_64\bin\aarch64-linux-android28-clang.cmd']
-cpp = ['C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk\28.0.12674087\toolchains\llvm\prebuilt\windows-x86_64\bin\aarch64-linux-android28-clang++.cmd']
-c_ld = ['C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk\28.0.12674087\toolchains\llvm\prebuilt\windows-x86_64\bin\ld.lld']
-cpp_ld = ['C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk\28.0.12674087\toolchains\llvm\prebuilt\windows-x86_64\bin\ld.lld']
-strip = ['C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk\28.0.12674087\toolchains\llvm\prebuilt\windows-x86_64\bin\llvm-strip']
+ar = ['C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk\27.2.12479018\toolchains\llvm\prebuilt\windows-x86_64\bin\llvm-ar']
+c = ['C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk\27.2.12479018\toolchains\llvm\prebuilt\windows-x86_64\bin\aarch64-linux-android28-clang.cmd']
+cpp = ['C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk\27.2.12479018\toolchains\llvm\prebuilt\windows-x86_64\bin\aarch64-linux-android28-clang++.cmd']
+c_ld = ['C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk\27.2.12479018\toolchains\llvm\prebuilt\windows-x86_64\bin\ld.lld']
+cpp_ld = ['C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk\27.2.12479018\toolchains\llvm\prebuilt\windows-x86_64\bin\ld.lld']
+strip = ['C:\Users\fivegmag\AppData\Local\Android\Sdk\ndk\27.2.12479018\toolchains\llvm\prebuilt\windows-x86_64\bin\llvm-strip']
 ```
 
 

--- a/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
+++ b/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
@@ -13,7 +13,7 @@ This guide covers compiling the XR player sample Unity project for Android and c
 
 This section assumes [adb](https://developer.android.com/tools/adb) is installed on the machine, and an Android device with [developer options and USB debugging](https://developer.android.com/studio/debug/dev-options#enable) enabled is connected.
 
-The project requires Unity 3D 2022.3 with both Android and iOS support modules installed. Note that Android API version is set to 26 with NDK 27.2.12479018.
+The project requires Unity 3D 2022.3.34f1 with both Android and iOS support modules installed. Note that Android API version is set to 26 with NDK 27.2.12479018.
 
 While this guide assumes a Windows environment with a git-bash terminal (eg. to run shell scripts), the same instructions apply to other platoforms.
 

--- a/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
+++ b/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
@@ -53,8 +53,7 @@ Copy the generated libraries into the avpipeline subproject:
 mkdir -p ./rt-xr-maf-native/subprojects/avpipeline/external/avcodec/android/arm64-v8a/lib
 cp ./rt-common-shared/avcodec-build/build/ffmpeg/aarch64/lib/*.so ./rt-xr-maf-native/subprojects/avpipeline/external/avcodec/android/arm64-v8a/lib
 
-mkdir -p ./rt-xr-maf-native/subprojects/avpipeline/external/avcodec/android/arm64-v8a/include
-cp -r ./rt-common-shared/avcodec-build/build/ffmpeg/aarch64/ ./rt-xr-maf-native/subprojects/avpipeline/external/avcodec/android/arm64-v8a/include
+cp -r ./rt-common-shared/avcodec-build/build/ffmpeg/aarch64/include ./rt-xr-maf-native/subprojects/avpipeline/external/avcodec/android/arm64-v8a/include/
 
 cp ./rt-common-shared/avcodec-build/build/ffmpeg/aarch64/LICENSE ./rt-xr-maf-native/subprojects/avpipeline/external/avcodec/android/arm64-v8a/LICENSE
 ```

--- a/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
+++ b/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
@@ -13,7 +13,7 @@ This guide covers compiling the XR player sample Unity project for Android and c
 
 This section assumes [adb](https://developer.android.com/tools/adb) is installed on the machine, and an Android device with [developer options and USB debugging](https://developer.android.com/studio/debug/dev-options#enable) enabled is connected.
 
-The project requires Unity 3D 2022.3 with both Android and iOS support modules installed. Note that Android API version is set to 26 with NDK 28.0.12674087.
+The project requires Unity 3D 2022.3 with both Android and iOS support modules installed. Note that Android API version is set to 26 with NDK 27.2.12479018.
 
 While this guide assumes a Windows environment with a git-bash terminal (eg. to run shell scripts), the same instructions apply to other platoforms.
 

--- a/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
+++ b/pages/xr-media-integration-in-5g/tutorials/xr-player-android.md
@@ -54,7 +54,7 @@ mkdir -p ./rt-xr-maf-native/subprojects/avpipeline/external/avcodec/android/arm6
 cp ./rt-common-shared/avcodec-build/build/ffmpeg/aarch64/lib/*.so ./rt-xr-maf-native/subprojects/avpipeline/external/avcodec/android/arm64-v8a/lib
 
 mkdir -p ./rt-xr-maf-native/subprojects/avpipeline/external/avcodec/android/arm64-v8a/include
-cp ./rt-common-shared/avcodec-build/build/ffmpeg/aarch64/include/* ./rt-xr-maf-native/subprojects/avpipeline/external/avcodec/android/arm64-v8a/include
+cp -r ./rt-common-shared/avcodec-build/build/ffmpeg/aarch64/include/ ./rt-xr-maf-native/subprojects/avpipeline/external/avcodec/android/arm64-v8a/include
 
 cp ./rt-common-shared/avcodec-build/build/ffmpeg/aarch64/LICENSE ./rt-xr-maf-native/subprojects/avpipeline/external/avcodec/android/arm64-v8a/LICENSE
 ```


### PR DESCRIPTION
I believe these changes are applicable to both building for smartphone and for Meta Quest.

If this is stable for smartphone as is we would just need to change the title (I'd just done it). In such case, I suggest making a copy to a tutorial for Meta Quest 3 with this one as baseline and we make the necessary changes for the build process, Unity project changes/checks and the insertion of the path to load the scene.